### PR TITLE
add errorCode in requestMessage#53

### DIFF
--- a/srcs/Client.cpp
+++ b/srcs/Client.cpp
@@ -169,6 +169,7 @@ void Client::readHeader(const char* buffer)
             if (req.headers.find("host") == req.headers.end())
             {
                 parseState = ERROR;
+                req.errorCode = BAD_REQUEST;
                 return;
             }
             else if (req.headers.find("content-length") == req.headers.end()
@@ -200,6 +201,7 @@ void Client::readHeader(const char* buffer)
         if (key.size() == 0)
         {
             parseState = ERROR;
+            req.errorCode = BAD_REQUEST;
             return;
         }
         for (size_t i = 0; i < key.size(); i++)
@@ -207,6 +209,7 @@ void Client::readHeader(const char* buffer)
             if (isspace(key[i]))
             {
                 parseState = ERROR;
+                req.errorCode = BAD_REQUEST;
                 return;
             }
         }
@@ -214,6 +217,7 @@ void Client::readHeader(const char* buffer)
         if (value.size() == 0)
         {
             parseState = ERROR;
+            req.errorCode = BAD_REQUEST;
             return;
         }
         headerSstream.clear();
@@ -262,6 +266,7 @@ void Client::readChunked(const char* buffer, size_t readSize)
             if (readBuffer[longBodySize] != '\r' || readBuffer[longBodySize + 1] != '\n')
             {
                 parseState = ERROR;
+                req.errorCode = BAD_REQUEST;
                 return ;
             }
             readBuffer.erase(readBuffer.begin(), readBuffer.begin() + longBodySize + 2);
@@ -320,12 +325,14 @@ void Client::readMethod(const char* buffer)
         else if ((pos = std::search(readBuffer.begin(), readBuffer.end(), "\r\n", &"\r\n"[2])) != readBuffer.end())
         {
             parseState = ERROR;
+            req.errorCode = BAD_REQUEST;
         }
     }
     // 공백이 아닌 개행을 읽은 경우 파싱이 완료되지 못하기 때문에 에러
     else if ((pos = std::search(readBuffer.begin(), readBuffer.end(), "\r\n", &"\r\n"[2])) != readBuffer.end())
     {
         parseState = ERROR;
+        req.errorCode = BAD_REQUEST;
         readBuffer.erase(readBuffer.begin(), pos + 2);
     }
 }
@@ -346,11 +353,13 @@ void Client::readUri(const char* buffer)
         else if ((pos = std::search(readBuffer.begin(), readBuffer.end(), " ", &" "[1])) != readBuffer.end())
         {
             parseState = ERROR;
+            req.errorCode = BAD_REQUEST;
         }
     }
     else if ((pos = std::search(readBuffer.begin(), readBuffer.end(), "\r\n", &"\r\n"[2])) != readBuffer.end())
     {
         parseState = ERROR;
+        req.errorCode = BAD_REQUEST;
         readBuffer.erase(readBuffer.begin(), pos + 2);
     }
 }
@@ -367,6 +376,7 @@ void Client::readHttpVersion(const char* buffer)
         if (req.httpVersion != "HTTP/1.1" && req.httpVersion != "HTTP/1.0")
         {
             parseState = ERROR;
+            req.errorCode = HTTP_VERSION_NOT_SUPPORT;
             return;
         }
         req.startLine += " " + req.httpVersion;

--- a/srcs/RequestMessage.hpp
+++ b/srcs/RequestMessage.hpp
@@ -1,6 +1,12 @@
 #pragma once
 #include "Message.hpp"
 
+enum ParseErrorCode
+{
+    BAD_REQUEST = 400,
+    HTTP_VERSION_NOT_SUPPORT = 505,
+};
+
 class RequestMessage : public Message
 {
 public:
@@ -10,6 +16,7 @@ public:
     RequestMessage& operator=(RequestMessage const& rhs);
     std::string method;
     std::string uri;
+    enum ParseErrorCode errorCode;
 
     void clear();
 };


### PR DESCRIPTION
parse단계에서 생기는 errro가 모두 bad request인것은 아님.
http version not support인 경우에도 파싱단에서 에러처리를 하는데 그때 왜 에러가 났는지를 requestMessage안에 에러코드를 넣어 확인할 수 있게함.

requestMessage를 BE에서 처음받아 확인하는 첫 변수로 사용할 수 있을 것 같음