### PR TITLE
Find error page by config#72

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,8 +3,7 @@ NAME = webserv
 
 # Cmd & Options
 CXX			= c++
-# CXXFLAGS	= -fsanitize=address -g -Wall -Werror -Wextra -std=c++98 -g3
-CXXFLAGS	= -g3
+CXXFLAGS	= -fsanitize=address -g -Wall -Werror -Wextra -std=c++98 -g3
 RM 			= rm
 RMFLAGS		= -f
 OUT_DIR		= objs

--- a/config/default.conf
+++ b/config/default.conf
@@ -21,6 +21,7 @@ server {
 server {
     listen      80 ;
     server_name localhost ;
+    error_page 404 403 ./error_pages/404.html ;
 
     location / {
         allow_method GET POST ;

--- a/srcs/Client.cpp
+++ b/srcs/Client.cpp
@@ -19,7 +19,7 @@ Client::~Client() {}
 Client::Client(Client const& other)
 	: client_fd(other.client_fd), server(other.server),
 	  queRes(other.queRes), readBuffer(other.readBuffer),
-	  sendBuffer(other.sendBuffer), parseState(METHOD) {}
+	  parseState(READY), sendBuffer(other.sendBuffer){}
 // operators
 Client& Client::operator=(Client const& rhs)
 {
@@ -66,8 +66,6 @@ bool Client::readEventProcess(void) // RUN 5
 	{
 		// 메시지 처리하여 버퍼에 입력해야함.
 		// events.changeEvents(ident, EVFILT_WRITE, EV_ENABLE, 0, 0, NULL);
-		HttpRequest&	request = this->httpRequestManager.getRequest();
-
 		httpRequestManager.SetHandler(*this);
 		httpRequestManager.DynamicOpenFd(*this);
 		httpRequestManager.SendReqtoEvent(*this);
@@ -231,7 +229,7 @@ void Client::readChunked(const char* buffer, size_t readSize)
 {
 	static const char* crlf = "\r\n";
 	static std::string strbodySize;
-	static long longBodySize;
+	static size_t longBodySize;
 	static bool haveToReadBody = false;
 	HttpRequest& req = httpRequestManager.getBackReq();
 

--- a/srcs/ClientManager.cpp
+++ b/srcs/ClientManager.cpp
@@ -83,7 +83,7 @@ int ClientManager::ReqToCgiWriteProcess(struct kevent& currEvent)
 
 int ClientManager::CgiToResReadProcess(struct kevent& currEvent)
 {
-    const size_t BUFFER_SIZE = 1024;
+    const ssize_t BUFFER_SIZE = 1024;
 
     Client* currClient = reinterpret_cast<Client*>(currEvent.udata);
     std::vector<unsigned char>& readBuffer = currClient->getFrontRes().body;

--- a/srcs/Http/Handler/DynamicHandler.cpp
+++ b/srcs/Http/Handler/DynamicHandler.cpp
@@ -54,11 +54,7 @@ void DynamicHandler::RunCgi(Client& client)
 		setenv("CONTENT_LENGTH", size_cstr, 1);
 
 		if (execve(request.path.c_str(), NULL, environ) == -1)
-		{
-			// TODO: Handle Error
 			std::cerr << "execve error" << std::endl;
-			exit(0);
-		}
 	}
 	else
 	{
@@ -85,6 +81,10 @@ std::vector<unsigned char>	DynamicHandler::handle(Client& client) const
 	static_cast<void>(client);
 	std::vector<unsigned char> result;
 	return result;
+}
+
+DynamicHandler::DynamicHandler(Client const& client) : Handler(client)
+{
 }
 
 DynamicHandler::~DynamicHandler()

--- a/srcs/Http/Handler/DynamicHandler.hpp
+++ b/srcs/Http/Handler/DynamicHandler.hpp
@@ -6,6 +6,7 @@
 class DynamicHandler : public Handler
 {
 	public:
+		DynamicHandler(Client const& client);
 		std::vector<unsigned char>	handle(Client& client) const;
 		void OpenFd(Client& client);
 		void SendReqtoCgi(Client& client);

--- a/srcs/Http/Handler/ErrorHandler.cpp
+++ b/srcs/Http/Handler/ErrorHandler.cpp
@@ -1,14 +1,39 @@
 #include "ErrorHandler.hpp"
+#include "../../Client.hpp"
 
-std::vector<unsigned char>	ErrorHandler::handler(int status_code)
+std::vector<unsigned char>	ErrorHandler::handler(Client& client, int status_code)
 {
 	std::vector<unsigned char>			body;
 	std::map<std::string, std::string>	headers;
+	std::string							file_name;
+	std::map<std::vector<int>, std::string> const& errorPage = client.getServer()->getErrorPage();
+	bool								find_flag = false;
 
-	// TODO: Config에서 맞게 읽어도록 하기
-	std::string	file_name = "./error_pages/404.html";
+	std::map<std::vector<int>, std::string>::const_iterator it = errorPage.begin();
+	for (; it != errorPage.end(); it++)
+	{
+		std::vector<int>::const_iterator it2 = it->first.begin();
+		for (; it2 != it->first.end(); it2++)
+		{
+			if (status_code == *it2)
+			{
+				find_flag = true;
+				break ;
+			}
+		}
+		if (find_flag)
+			break ;
+	}
+	if (find_flag)
+		file_name = it->second;
+	else
+		file_name = "./error_pages/404.html";
 	body = ReadStaticFile(file_name);
 	headers["Connection"] = "close";
 	headers["Content-Type"] = GetFileType(file_name);
 	return BuildResponse(status_code, headers, body);
+}
+
+ErrorHandler::ErrorHandler(Client const& client) : Handler(client)
+{
 }

--- a/srcs/Http/Handler/ErrorHandler.hpp
+++ b/srcs/Http/Handler/ErrorHandler.hpp
@@ -7,5 +7,6 @@ class ErrorHandler : public Handler
 	private:
 
 	public:
-		static std::vector<unsigned char>	handler(int status_code);
+		ErrorHandler(Client const&);
+		static std::vector<unsigned char>	handler(Client& client, int status_code);
 };

--- a/srcs/Http/Handler/Handler.cpp
+++ b/srcs/Http/Handler/Handler.cpp
@@ -123,19 +123,24 @@ std::vector<unsigned char>	Handler::ReadStaticFile(std::string& file_name)
 	return buffer;
 }
 
-std::vector<unsigned char>	Handler::ServeStatic(std::string& path)
+std::vector<unsigned char>	Handler::ServeStatic(Client& client, std::string& path)
 {
 	std::vector<unsigned char>			body;
 	std::map<std::string, std::string>	headers;
 
 	if (!IsFileExist(path))
-		return ErrorHandler::handler(404);
+		return ErrorHandler::handler(client, 404);
 	if (!IsRegularFile(path) || !IsFileReadble(path))
-		return ErrorHandler::handler(403);
+		return ErrorHandler::handler(client, 403);
 	body = ReadStaticFile(path);
 	headers["Connection"] = "close";
 	headers["Content-Type"] = GetFileType(path);
 	return BuildResponse(200, headers, body);
+}
+
+Handler::Handler(Client const& client)
+{
+	static_cast<void>(client);
 }
 
 Handler::~Handler()

--- a/srcs/Http/Handler/Handler.hpp
+++ b/srcs/Http/Handler/Handler.hpp
@@ -21,6 +21,7 @@ class Handler
 {
 	private:
 	public:
+		Handler(Client const &);
 		static std::vector<unsigned char>	BuildHeader(int status_code, std::map<std::string, std::string>& headers, bool include_crlf=true);
 		static std::string	GetFileType(std::string file_name);
 		static std::string	itos(int num);
@@ -31,7 +32,7 @@ class Handler
 		static bool		IsRegularFile(std::string path);
 		static bool		IsFileReadble(std::string path);
 		static bool		IsFileExist(std::string path);
-		static std::vector<unsigned char>	ServeStatic(std::string& path);
+		static std::vector<unsigned char>	ServeStatic(Client& client, std::string& path);
 		virtual std::vector<unsigned char>	handle(Client& client) const = 0;
 		virtual ~Handler();
 };

--- a/srcs/Http/Handler/StaticHandler.cpp
+++ b/srcs/Http/Handler/StaticHandler.cpp
@@ -11,7 +11,7 @@ std::vector<unsigned char>	StaticHandler::handle(Client& client) const
 	// is_directopy
     if (IsDirectory(request.path))
         return ProcessDirectory(client);
-	return ServeStatic(request.path);
+	return ServeStatic(client, request.path);
 }
 
 int	is_directory(std::string fileName)
@@ -21,7 +21,7 @@ int	is_directory(std::string fileName)
 	return (0);
 }
 
-std::vector<unsigned char>	StaticHandler::HandleDirectoryListing(HttpRequest& request) const
+std::vector<unsigned char>	StaticHandler::HandleDirectoryListing(Client& client, HttpRequest& request) const
 {	
 	std::vector<unsigned char>			body;
 	std::map<std::string, std::string>	headers;
@@ -30,7 +30,7 @@ std::vector<unsigned char>	StaticHandler::HandleDirectoryListing(HttpRequest& re
 	if (!dir) 
 	// Error Handler를 호출해야 하는 첫 번째 경우 (errnum = 1), 
 	// 현재 default.conf의 root는 /html로 지정되어 있는데, 그 /html이 없는 경우이다.
-		return ErrorHandler::handler(404);
+		return ErrorHandler::handler(client, 404);
 
 	std::stringstream	ss;
 	ss << "<!DOCTYPE html><head><title>Index of " << request.path;
@@ -69,12 +69,16 @@ std::vector<unsigned char>	StaticHandler::ProcessDirectory(Client& client) const
 		{
 			request.path = path;
 			std::cout << BOLDRED << "PATH : " << path << RESET << '\n';
-			return ServeStatic(request.path);
+			return ServeStatic(client, request.path);
 		}
 	}
 	if (request.location.getAutoIndex())
-		return HandleDirectoryListing(request);
-	return ErrorHandler::handler(404);
+		return HandleDirectoryListing(client, request);
+	return ErrorHandler::handler(client, 404);
+}
+
+StaticHandler::StaticHandler(Client const& client) : Handler(client)
+{
 }
 
 StaticHandler::~StaticHandler()

--- a/srcs/Http/Handler/StaticHandler.hpp
+++ b/srcs/Http/Handler/StaticHandler.hpp
@@ -6,10 +6,11 @@ class StaticHandler : public Handler
 {
 	public:
 		std::vector<unsigned char>	handle(Client& client) const;
+		StaticHandler(Client const& client);
 		~StaticHandler();
 		void sendReqtoEvent(Client& client);
 		std::vector<unsigned char>	ProcessDirectory(Client& client) const;
-		std::vector<unsigned char>	HandleDirectoryListing(HttpRequest& request) const;
+		std::vector<unsigned char>	HandleDirectoryListing(Client& client, HttpRequest& request) const;
 };
 
 int	is_directory(std::string fileName);

--- a/srcs/Http/HttpRequestManager.cpp
+++ b/srcs/Http/HttpRequestManager.cpp
@@ -12,12 +12,12 @@ void	HttpRequestManager::SetHandler(Client& client)
 	if (getFrontReq().is_static)
 	{
 		std::cout << BOLDRED << " -- PROCESSING STATIC -- \n";
-		handler = new StaticHandler();
+		handler = new StaticHandler(client);
 	}
 	else
 	{
 		std::cout << BOLDBLUE << " -- PROCESSING DYNAMIC --\n";
-		handler = new DynamicHandler();
+		handler = new DynamicHandler(client);
 	}
 }
 


### PR DESCRIPTION
config파일을 가져와 에러페이지를 찾고 만약에 에러페이지가 없으면 어떻게 처리해야할지 모호해서 일단 ./error_pages/404.html 을 가져오도록 하드코딩 되어있음.

config파일을 가져오기 위해서 handler가 client를 가지고 있게 수정함

close: #72 