### PR TITLE
remove evnet DELETE sentence

### DIFF
--- a/srcs/ServerManager.cpp
+++ b/srcs/ServerManager.cpp
@@ -116,7 +116,7 @@ void ServerManager::runServerManager(void) // RUN 1
 			exitWebServer("kevent() error");
 		events.clearChangeEventList();
 		for (int i = 0; i != newEvent; i++)
-		{ 
+		{
 			std::cout << events[i] << std::endl;
 			runEventProcess(events[i]); // (RUN 2)
 		}
@@ -199,18 +199,24 @@ void ServerManager::readEventProcess(struct kevent& currEvent) // RUN 3
         events.changeEvents(currEvent.ident, EVFILT_TIMER, EV_EOF, NOTE_SECONDS, 100, currEvent.udata);
         if (clientManager.readEventProcess(currEvent))
         {
-			
+
             events.changeEvents(currEvent.ident, EVFILT_WRITE, EV_ENABLE, 0, 0, currEvent.udata);
         }
     }
     else // file Read event...
     {
-        //Cgi에서 보내는 data 를 response의 body 에 저장 
+        //Cgi에서 보내는 data 를 response의 body 에 저장
         ssize_t ret = clientManager.CgiToResReadProcess(currEvent); // -1: read error, 0 : read left 1 : read done
         if (ret != 0) // read error || read done
         {
+<<<<<<< Updated upstream
 			events.changeEvents(currEvent.ident, EVFILT_TIMER, EV_DELETE, NOTE_SECONDS, 10, NULL);
             events.changeEvents(currEvent.ident, EVFILT_READ, EV_DELETE, 0, 0, NULL);
+=======
+			// events.changeEvents(currEvent.ident, EVFILT_TIMER, EV_DELETE, NOTE_SECONDS, 10, NULL);
+            // events.changeEvents(currEvent.ident, EVFILT_READ, EV_DELETE, 0, 0, NULL);
+			close(currClient->httpRequestManager.getRequest().pipe_fd_back[0]);
+>>>>>>> Stashed changes
 			currClient->httpRequestManager.popReq();
 			close(currClient->httpRequestManager.getRequest().pipe_fd_back[0]);
 			
@@ -218,7 +224,7 @@ void ServerManager::readEventProcess(struct kevent& currEvent) // RUN 3
         if (ret == 1)
         {
             // cgi 에서 결과물을 받을때 response 가 완성 되어있다면, client 로 바로 전송 하도록 이벤트를 보냄
-			
+
 			currClient->sendBuffer = Handler::BuildResponse(currClient->getFrontRes().status_code, currClient->getFrontRes().headers, currClient->getFrontRes().body, true);
 			events.changeEvents(currClient->getClientFd(), EVFILT_WRITE, EV_ENABLE, 0, 0, currClient);
 			// currClient->sendBuffer.insert(currClient->sendBuffer.end(), currClient->getFrontRes().body.begin(), currClient->getFrontRes().body.end());
@@ -226,7 +232,7 @@ void ServerManager::readEventProcess(struct kevent& currEvent) // RUN 3
 			// currClient->sendBuffer.insert(currClient->sendBuffer.end(), CRLF[0], CRLF[2]);
 			currClient->popRes();
 			wait(NULL);
-            // 위의 경우가 아닌 경우에는 client 의 response 메시지를 만드는 function 을 호출한다. 
+            // 위의 경우가 아닌 경우에는 client 의 response 메시지를 만드는 function 을 호출한다.
             // 예 : currClient->getRes().buildResponse();
         }
 		else
@@ -261,7 +267,7 @@ void ServerManager::writeEventProcess(struct kevent& currEvent)
 
 void ServerManager::timerEventProcess(struct kevent& currEvent)
 {
-	events.changeEvents(currEvent.ident, EVFILT_TIMER, EV_DELETE, 0, 0, currEvent.udata);
+	// events.changeEvents(currEvent.ident, EVFILT_TIMER, EV_DELETE, 0, 0, currEvent.udata);
 	clientManager.disconnectClient(currEvent.ident);
 }
 


### PR DESCRIPTION
fd를 close하면 자동으로 kqueue이벤트에서 삭제가 되는데, 다음 kevent루프때 이벤트를 DELETE하려고 시도하기 때문에 EV_ERROR가 가는 것으로 보여 이벤트를 필요없이 DELETE하는 구문들을 삭제함

close : #97 